### PR TITLE
Improve typings and clean forms

### DIFF
--- a/src/components/config/GoogleAuthSection.tsx
+++ b/src/components/config/GoogleAuthSection.tsx
@@ -4,7 +4,12 @@ import { Input } from "@/components/ui/input";
 import { Loader, ExternalLink, Info, AlertTriangle, Check, Copy, RefreshCw, Trash2, Bug } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
-import { initiateGoogleAuth, clearPlatformToken, validateGoogleAuthConfig } from "@/utils/googleAuth";
+import {
+  initiateGoogleAuth,
+  clearPlatformToken,
+  validateGoogleAuthConfig,
+  GoogleAuthConfigValidation,
+} from "@/utils/googleAuth";
 import { 
   Accordion,
   AccordionContent,
@@ -53,7 +58,7 @@ export const GoogleAuthSection: React.FC<GoogleAuthSectionProps> = ({
   const [showSecret, setShowSecret] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
   const [accordionOpen, setAccordionOpen] = useState<string | undefined>(googleAuthStatus === "error" ? "troubleshooting" : undefined);
-  const [configValidation, setConfigValidation] = useState<any>(null);
+  const [configValidation, setConfigValidation] = useState<GoogleAuthConfigValidation | null>(null);
 
   // If there's an error, open the troubleshooting accordion
   useEffect(() => {

--- a/src/components/content/NewContentForm.tsx
+++ b/src/components/content/NewContentForm.tsx
@@ -13,10 +13,26 @@ interface NewContentFormProps {
   onClose: () => void;
 }
 
+type ContentType =
+  | 'blog'
+  | 'ebook'
+  | 'infografico'
+  | 'webinar'
+  | 'video'
+  | 'podcast'
+  | 'post-social';
+type ContentObjective =
+  | 'conscientizacao'
+  | 'educacao'
+  | 'conversao'
+  | 'lead'
+  | 'autoridade'
+  | 'engajamento';
+
 export const NewContentForm = ({ onClose }: NewContentFormProps) => {
   const [title, setTitle] = useState('');
-  const [type, setType] = useState('');
-  const [objective, setObjective] = useState('');
+  const [type, setType] = useState<ContentType | ''>('');
+  const [objective, setObjective] = useState<ContentObjective | ''>('');
   const [persona, setPersona] = useState('');
   const [deadline, setDeadline] = useState('');
   const [keywords, setKeywords] = useState<string[]>([]);
@@ -36,16 +52,15 @@ export const NewContentForm = ({ onClose }: NewContentFormProps) => {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    // Aqui você implementaria a lógica para salvar o conteúdo
-    console.log({
-      title,
-      type,
-      objective,
-      persona,
-      deadline,
-      keywords,
-      notes
-    });
+    // TODO: enviar dados para API ou serviço de persistência
+    setTitle('');
+    setType('');
+    setObjective('');
+    setPersona('');
+    setDeadline('');
+    setKeywords([]);
+    setKeywordInput('');
+    setNotes('');
     onClose();
   };
 

--- a/src/components/crm/CRMAnalysis.tsx
+++ b/src/components/crm/CRMAnalysis.tsx
@@ -14,6 +14,19 @@ import {
   CheckCircle
 } from "lucide-react";
 
+interface ModuleStatus {
+  name: string;
+  completion: number;
+  features: string[];
+}
+
+interface Improvement {
+  priority: 'Alta' | 'Média' | 'Baixa';
+  module: string;
+  suggestion: string;
+  impact: string;
+}
+
 export const CRMAnalysis = () => {
   const crmMetrics = {
     totalLeads: 145,
@@ -26,7 +39,7 @@ export const CRMAnalysis = () => {
     completionRate: 76
   };
 
-  const moduleStatus = [
+  const moduleStatus: ModuleStatus[] = [
     { name: 'Gestão Comercial', completion: 95, features: ['Pipeline', 'Oportunidades', 'Orçamentos', 'Funil'] },
     { name: 'Módulo Financeiro', completion: 90, features: ['Receitas', 'Despesas', 'Fluxo de Caixa', 'Relatórios'] },
     { name: 'Planejamento de Conteúdo', completion: 85, features: ['Calendário', 'Estratégias', 'Templates', 'Analytics'] },
@@ -34,7 +47,7 @@ export const CRMAnalysis = () => {
     { name: 'Relatórios e Analytics', completion: 80, features: ['Dashboards', 'KPIs', 'Exportação'] }
   ];
 
-  const recommendedImprovements = [
+  const recommendedImprovements: Improvement[] = [
     {
       priority: 'Alta',
       module: 'CRM',

--- a/src/components/customers/CustomerForm.tsx
+++ b/src/components/customers/CustomerForm.tsx
@@ -56,7 +56,10 @@ export const CustomerForm = ({ onSubmit, onCancel, initialData, mode = 'create' 
     });
   };
 
-  const handleChange = (field: keyof CustomerFormData, value: any) => {
+  const handleChange = <K extends keyof CustomerFormData>(
+    field: K,
+    value: CustomerFormData[K]
+  ) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -5,9 +5,11 @@ import { Button } from "@/components/ui/button";
 import { Filter, Download, BarChart3 } from "lucide-react";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 
+type RangeOption = '7d' | '30d' | '90d' | '12m';
+
 interface DashboardHeaderProps {
-  dateRange: string;
-  setDateRange: (value: string) => void;
+  dateRange: RangeOption;
+  setDateRange: (value: RangeOption) => void;
 }
 
 export const DashboardHeader = ({ dateRange, setDateRange }: DashboardHeaderProps) => {

--- a/src/components/financial/CashFlowManager.tsx
+++ b/src/components/financial/CashFlowManager.tsx
@@ -10,16 +10,27 @@ import { NewTransactionForm } from "./NewTransactionForm";
 import { useTransactions, useDeleteTransaction } from "@/hooks/useTransactions";
 import { toast } from "@/hooks/use-toast";
 
+interface CashFlowItem {
+  id: number;
+  date: string;
+  description: string;
+  category: string;
+  type: 'ENTRADA' | 'SAIDA';
+  value: number;
+  status: string;
+  method: string;
+}
+
 export const CashFlowManager = () => {
   const [viewPeriod, setViewPeriod] = useState('month');
   const [showNewTransactionForm, setShowNewTransactionForm] = useState(false);
-  const [editingTransaction, setEditingTransaction] = useState<any>(null);
+  const [editingTransaction, setEditingTransaction] = useState<CashFlowItem | null>(null);
   
   const { data: transactions = [], isLoading } = useTransactions();
   const deleteTransaction = useDeleteTransaction();
 
   // Dados do fluxo de caixa baseados na planilha
-  const cashFlowData = [
+  const cashFlowData: CashFlowItem[] = [
     {
       id: 1,
       date: '02/jan',
@@ -95,7 +106,7 @@ export const CashFlowManager = () => {
       : 'text-red-600 font-semibold';
   };
 
-  const handleEdit = (transaction: any) => {
+  const handleEdit = (transaction: CashFlowItem) => {
     setEditingTransaction(transaction);
     setShowNewTransactionForm(true);
   };

--- a/src/components/financial/DataValidationTool.tsx
+++ b/src/components/financial/DataValidationTool.tsx
@@ -291,7 +291,9 @@ export const DataValidationTool = () => {
               <Filter className="h-4 w-4" />
               <select
                 value={filterType}
-                onChange={(e) => setFilterType(e.target.value as any)}
+                onChange={(e) =>
+                  setFilterType(e.target.value as 'all' | 'valid' | 'invalid')
+                }
                 className="border rounded px-3 py-2"
               >
                 <option value="all">Todas</option>

--- a/src/utils/googleAuth.ts
+++ b/src/utils/googleAuth.ts
@@ -254,7 +254,17 @@ export const clearPlatformToken = (platform: 'google' | 'facebook' | 'linkedin')
  * @param redirectUri URI de redirecionamento
  * @returns Objeto com resultado da validação
  */
-export const validateGoogleAuthConfig = (clientId: string, redirectUri: string) => {
+export interface GoogleAuthConfigValidation {
+  isValid: boolean;
+  issues: string[];
+  redirectUri: string;
+  clientIdValid: boolean;
+}
+
+export const validateGoogleAuthConfig = (
+  clientId: string,
+  redirectUri: string
+): GoogleAuthConfigValidation => {
   const issues = [];
   
   if (!clientId) {


### PR DESCRIPTION
## Summary
- add `GoogleAuthConfigValidation` type
- use the new type in `GoogleAuthSection`
- tighten types in `NewContentForm` and reset fields after save
- add typed helpers in `CRMAnalysis`
- improve `handleChange` generics in `CustomerForm`
- restrict dashboard range options
- type cash flow items and editing state in `CashFlowManager`
- fix filter type cast in `DataValidationTool`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68823bb66e9483298e0c1421a39d436f